### PR TITLE
Store extracted headlines in S3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "flake8~=6.0.0",
+    "moto~=4.1.9",
     "mypy~=1.2.0",
     "pre-commit~=3.2.2",
     "pytest~=7.3.1",
@@ -17,6 +18,7 @@ test = [
 
 extract = [
     "beautifulsoup4~=4.12.2",
+    "boto3~=1.26.130",
     "requests~=2.28.2"
 ]
 

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -4,3 +4,9 @@ def get_request_headers() -> dict[str, str]:
                                 AppleWebKit/537.36 (KHTML, like Gecko) \
                                 Chrome/50.0.2661.102 Safari/537.36""",
     }
+
+
+def get_s3_bucket_name() -> str:
+    import os
+
+    return os.environ.get("TF_VAR_NEWSWATCH_S3_BUCKET", "")

--- a/src/common/models.py
+++ b/src/common/models.py
@@ -17,7 +17,7 @@ class SiteWithBsMatchFilters(BaseModel):
     filters: list[BsMatchFilter]
 
 
-class SiteHeadlineRecords(BaseModel):
+class SiteHeadlineCollection(BaseModel):
     name: StrictStr
     timestamp: datetime
     headlines: list[StrictStr]

--- a/tests/unit/extract/conftest.py
+++ b/tests/unit/extract/conftest.py
@@ -1,5 +1,8 @@
+import datetime
+
 import pytest
 from common.models import BsMatchFilter
+from common.models import SiteHeadlineCollection
 from common.models import SiteWithBsMatchFilters
 from pydantic import HttpUrl
 from pydantic.tools import parse_obj_as
@@ -52,3 +55,27 @@ def expected_headlines():
         "site3": set(["More p tags", "Hey ho, let's go!"]),
         "site4": set(["yes", "YES"]),
     }
+
+
+@pytest.fixture
+def site_headline_collections():
+    return [
+        SiteHeadlineCollection(
+            name="abc",
+            timestamp=datetime.datetime(2021, 10, 10, 10, 10, 10, tzinfo=datetime.timezone.utc),
+            headlines=["abc", "xyz", "123"],
+        ),
+        SiteHeadlineCollection(
+            name="def",
+            timestamp=datetime.datetime(2022, 10, 10, 10, 10, 10, tzinfo=datetime.timezone.utc),
+            headlines=["def", "zzz", "456"],
+        ),
+    ]
+
+
+@pytest.fixture
+def expected_json_string():
+    return (
+        """[{"name": "abc", "timestamp": "2021-10-10 10:10:10+00:00", "headlines": ["abc", "xyz", "123"]}, """
+        """{"name": "def", "timestamp": "2022-10-10 10:10:10+00:00", "headlines": ["def", "zzz", "456"]}]"""
+    )


### PR DESCRIPTION
* Upload headlines to S3 instead of saving them in a local file
* Make small improvements in naming, type hints and comments