### PR TITLE
Enable caching wordnet corpus in S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+tmp/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/src/extract.py
+++ b/src/extract.py
@@ -11,7 +11,7 @@ from common.utils import (
     coalesce_dict_values,
     convert_objects_to_json_string,
     get_current_timestamp,
-    upload_data_to_s3,
+    put_to_s3,
 )
 
 
@@ -69,7 +69,7 @@ def extract():
 
     object_key: str = build_s3_key(prefix=extract_s3_prefix, timestamp=timestamp_at_start, extension="json")
 
-    s3_response: dict = upload_data_to_s3(
+    s3_response: dict = put_to_s3(
         bucket_name=s3_bucket_name,
         key=object_key,
         data=convert_objects_to_json_string(site_headline_lists),
@@ -91,8 +91,8 @@ logger = logging.getLogger()
 
 request_headers = {
     "User-Agent": """Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) \
-                            AppleWebKit/537.36 (KHTML, like Gecko) \
-                            Chrome/50.0.2661.102 Safari/537.36""",
+                            AppleWebKit/603.1 (KHTML, like Gecko) \
+                            Chrome/117.0.0.0 Safari/537.36""",
 }
 
 s3_bucket_name = os.environ.get("S3_BUCKET_NAME", "")

--- a/src/load.py
+++ b/src/load.py
@@ -7,7 +7,7 @@ from common.utils import (
     DeleteFailedError,
     convert_json_string_to_objects,
     delete_timestamp_from_bigquery,
-    download_data_from_s3,
+    get_from_s3,
     extract_s3_bucket_and_key_from_event,
     get_datetime_from_s3_key,
     insert_data_into_bigquery_table,
@@ -45,7 +45,7 @@ def generate_load_records(word_frequencies: WordFrequencies, timestamp_str: str)
 def load(bucket: str, word_frequencies_key: str):
     logger.info(f"Loading word frequencies from {bucket}/{word_frequencies_key}")
 
-    data: str = download_data_from_s3(bucket_name=bucket, key=word_frequencies_key)
+    data: str = get_from_s3(bucket_name=bucket, key=word_frequencies_key)
     word_frequencies: WordFrequencies = convert_json_string_to_objects(json_string=f"{data}", cls=WordFrequencies)[0]
     filtered_word_frequencies: WordFrequencies = filter_word_frequencies(word_frequencies=word_frequencies)
 
@@ -82,7 +82,6 @@ else:
 
 logger = logging.getLogger()
 
-s3_bucket_name = os.environ.get("S3_BUCKET_NAME", "")
 bigquery_table_id = os.environ.get("BIGQUERY_TABLE_ID", "")
 bigquery_delete_before_write = os.environ.get("BIGQUERY_DELETE_BEFORE_WRITE", "false").lower()
 min_word_length = int(os.environ.get("MIN_WORD_LENGTH", "99"))

--- a/template.yaml
+++ b/template.yaml
@@ -49,7 +49,7 @@ Mappings:
       SitesYamlPath: resources/sites-with-filters-uk.yaml
       BackwardsCompatibleSuffix: dev
     live-uk:
-      ExtractSchedule: cron(30 * * * ? *)
+      ExtractSchedule: cron(5 * * * ? *)
       SitesYamlPath: resources/sites-with-filters-uk.yaml
       BackwardsCompatibleSuffix: live
     dev-us:
@@ -57,7 +57,7 @@ Mappings:
       SitesYamlPath: resources/sites-with-filters-us.yaml
       BackwardsCompatibleSuffix: dev-us
     live-us:
-      ExtractSchedule: cron(30 * * * ? *)
+      ExtractSchedule: cron(5 * * * ? *)
       SitesYamlPath: resources/sites-with-filters-us.yaml
       BackwardsCompatibleSuffix: live-us
 
@@ -197,7 +197,6 @@ Resources:
           BucketName: !Ref NewswatchS3Bucket
       Environment:
         Variables:
-          S3_BUCKET_NAME: !Ref NewswatchS3Bucket
           TRANSFORM_S3_PREFIX: !Ref TransformS3Prefix
       Tags:
         project: !Ref ProjectTag
@@ -220,7 +219,6 @@ Resources:
             ParameterName: NewsWatchBigQueryCredentials
       Environment:
         Variables:
-          S3_BUCKET_NAME: !Ref NewswatchS3Bucket
           BIGQUERY_TABLE_ID: !Sub
             - "${NewsWatchBigQueryTableId}-${Suffix}"
             - Suffix: !FindInMap [ EnvMapping, !Ref Env, BackwardsCompatibleSuffix ]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -18,6 +18,7 @@ from transform import lambda_handler as transform_lambda_handler
 s3_bucket_name = "test-bucket"
 extract_s3_prefix = "extracted-headlines"
 transform_s3_prefix = "word-frequencies"
+transform_writable_path = "./tmp"
 bigquery_table = "nwproject.nwdataset.nwtable"
 bigquery_delete_before_write = "true"
 min_word_length = 3
@@ -145,6 +146,7 @@ mock_bigquery_client = MockBigQueryClient()
 @patch("extract.extract_s3_prefix", extract_s3_prefix)
 @patch("extract.get_current_timestamp", return_value=timestamp)
 @patch("transform.transform_s3_prefix", transform_s3_prefix)
+@patch("transform.writable_path", transform_writable_path)
 @patch("load.bigquery_table_id", bigquery_table)
 @patch("load.bigquery_delete_before_write", bigquery_delete_before_write)
 @patch("load.min_word_length", min_word_length)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,15 +5,17 @@ import boto3
 import moto
 import pytest
 
+
 from common.utils import (
     build_s3_key,
     coalesce_dict_values,
     convert_objects_to_json_string,
     extract_s3_bucket_and_key_from_event,
     get_datetime_from_s3_key,
+    get_from_s3,
     merge_dictionaries_summing_values,
     sort_dict_by_value,
-    upload_data_to_s3,
+    put_to_s3,
 )
 
 
@@ -112,17 +114,26 @@ def test_extract_s3_bucket_and_key_from_event():
     assert extract_s3_bucket_and_key_from_event(test_event) == (expected_bucket, expected_key)
 
 
+# TODO: Test S3 operations
+
+
 @moto.mock_s3
-def test_upload_data_to_s3():
+def test_put_to_s3():
     test_bucket, test_key, test_data = "test-bucket", "test-object-key", '{"test": "test"}'
     s3_client = boto3.client("s3", region_name="us-east-1")
     s3_client.create_bucket(Bucket=test_bucket)
 
-    response = upload_data_to_s3(bucket_name=test_bucket, key=test_key, data=test_data)
+    response = put_to_s3(bucket_name=test_bucket, key=test_key, data=test_data)
 
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
     assert s3_client.get_object(Bucket=test_bucket, Key=test_key)["Body"].read().decode("utf-8") == test_data
 
 
-def test_insert_data_into_bigquery_table():
-    pass
+@moto.mock_s3
+def test_get_from_s3():
+    test_bucket, test_key, test_data = "test-bucket", "test-object-key", '{"test": "test"}'
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket=test_bucket)
+    s3_client.put_object(Bucket=test_bucket, Key=test_key, Body=test_data)
+
+    assert get_from_s3(bucket_name=test_bucket, key=test_key) == test_data


### PR DESCRIPTION
* Remove unused S3 bucket env variable from transform and load functions
* Save cached version of the wordnet corpus in S3 and reuse it for a week
* Move extraction schedule closer to the start of the hour
* Add some of the missing tests for utils.py