### PR TITLE
Prevent site structure changes breaking transformations

### DIFF
--- a/src/resources/sites-with-filters-uk.yaml
+++ b/src/resources/sites-with-filters-uk.yaml
@@ -46,9 +46,7 @@
   url: https://www.standard.co.uk/
   filters:
     - tag: h2
-    - tag: div
-      attrs:
-        class: headline
+    - tag: p
 - name: star
   url: https://www.dailystar.co.uk/
   filters:

--- a/template.yaml
+++ b/template.yaml
@@ -198,6 +198,7 @@ Resources:
       Environment:
         Variables:
           TRANSFORM_S3_PREFIX: !Ref TransformS3Prefix
+          TRANSFORM_WORD_COUNT_THRESHOLD: 100
       Tags:
         project: !Ref ProjectTag
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -19,6 +19,7 @@ s3_bucket_name = "test-bucket"
 extract_s3_prefix = "extracted-headlines"
 transform_s3_prefix = "word-frequencies"
 transform_writable_path = "./tmp"
+transform_word_count_threshold = 0
 bigquery_table = "nwproject.nwdataset.nwtable"
 bigquery_delete_before_write = "true"
 min_word_length = 3
@@ -147,6 +148,7 @@ mock_bigquery_client = MockBigQueryClient()
 @patch("extract.get_current_timestamp", return_value=timestamp)
 @patch("transform.transform_s3_prefix", transform_s3_prefix)
 @patch("transform.writable_path", transform_writable_path)
+@patch("transform.word_count_threshold", transform_word_count_threshold)
 @patch("load.bigquery_table_id", bigquery_table)
 @patch("load.bigquery_delete_before_write", bigquery_delete_before_write)
 @patch("load.min_word_length", min_word_length)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -83,5 +83,6 @@ def test_merge_site_word_frequencies(
     test_word_frequencies: WordFrequencies,
 ) -> None:
     assert (
-        merge_site_word_frequencies(test_site_word_frequencies_collection) == test_word_frequencies
+        merge_site_word_frequencies(test_site_word_frequencies_collection, word_count_threshold=0)
+        == test_word_frequencies
     ), f"Merging site word frequencies failed for site word frequencies: {test_site_word_frequencies_collection}"


### PR DESCRIPTION
* Exclude site if too few words were scraped
* Update filter for a changed site
* Remove debug prints